### PR TITLE
do not use slashes in filenames

### DIFF
--- a/org.wireshark.Wireshark.yml
+++ b/org.wireshark.Wireshark.yml
@@ -28,7 +28,8 @@ modules:
           url-template: https://zlib.net/zlib-$version.tar.gz
 
       - type: script
-        dest-filename: contrib/minizip/autogen.sh
+        dest: contrib/minizip/
+        dest-filename: autogen.sh
         commands:
           - autoreconf -ifv
 


### PR DESCRIPTION
to overcome an error introduced in
https://github.com/flatpak/flatpak-builder/commit/a7d93af345cbd1ba1513fdb12505cf67e9a45f8c