### PR TITLE
krb5: update url template as the old wasn't working somehow

### DIFF
--- a/org.wireshark.Wireshark.yml
+++ b/org.wireshark.Wireshark.yml
@@ -231,7 +231,8 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 13287
-          url-template: https://ftp.osuosl.org/pub/blfs/conglomeration/krb5/krb5-$version.tar.gz
+          stable-only: true
+          url-template: https://github.com/krb5/krb5/archive/refs/tags/krb5-$version.tar.gz
 
   - name: libsmi
     sources:


### PR DESCRIPTION
It's github, unfortunately.
I've taken it from
https://github.com/flathub/org.chromium.Chromium.BaseApp/blob/efa3febf9dd6e64a3b6e6c10269d4893e1aab725/org.chromium.Chromium.BaseApp.yaml#L65