### PR TITLE
fix: issues when exporting or saving in home folder

### DIFF
--- a/org.wireshark.Wireshark.yml
+++ b/org.wireshark.Wireshark.yml
@@ -11,7 +11,7 @@ finish-args:
   # Because the file chooser somehow doesn't show the files on the host, we export some directory for reading pcap files
   # https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=15507
   - --filesystem=xdg-public-share
-  - --filesystem=home:ro
+  - --filesystem=home:rw
   # - --share=network
 
 


### PR DESCRIPTION
I tried exporting a search filter result in my home directory and it wouldn't work with the error that I was trying to write to a read-only filesystem. Others have been facing this problem too, eg., #28 and [Linux-Questions](https://www.linuxquestions.org/questions/linux-software-2/wireshark-does-not-have-permission-to-save-files-507913/).

Hope my solution is the correct one for this problem.