### PR TITLE
Update lua to 5.4.7

### DIFF
--- a/org.wireshark.Wireshark.yml
+++ b/org.wireshark.Wireshark.yml
@@ -77,7 +77,7 @@ modules:
           url-template: https://github.com/nghttp2/nghttp2/releases/download/v$version/nghttp2-$version.tar.gz
 
 
-  - name: lua52
+  - name: lua54
     cleanup:
       - /include
       - /man
@@ -90,13 +90,12 @@ modules:
       - INSTALL_TOP=/app
     sources:
       - type: archive
-        url: https://www.lua.org/ftp/lua-5.2.4.tar.gz
-        sha256: b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b
-        # Wireshark doesn't seems to support Lua version higher than 5.2
-        # x-checker-data:
-        #   type: anitya
-        #   project-id: 1847
-        #   url-template: https://www.lua.org/ftp/lua-$version.tar.gz
+        url: https://www.lua.org/ftp/lua-5.4.7.tar.gz
+        sha256: 9fbf5e28ef86c69858f6d3d34eccc32e911c1a28b4120ff3e84aaa70cfbf1e30
+        x-checker-data:
+          type: anitya
+          project-id: 1847
+          url-template: https://www.lua.org/ftp/lua-$version.tar.gz
 
 
   - name: libmaxminddb


### PR DESCRIPTION
As of [Wireshark 4.4.0](https://www.wireshark.org/docs/relnotes/wireshark-4.4.0), support for Lua 5.2 was removed, and Lua 5.3 and 5.4 are now supported. This means that the current Wireshark flatpak does not include Lua support:

```
$ flatpak run org.wireshark.Wireshark --version
Wireshark 4.4.0 (Git commit d2c2b3dcc818).

Compiled ...
... without Lua...
```

Update to lua 5.4.7, and re-enable the update checker.

Supersedes #87