### PR TITLE
wrapper: Make wrapper work with zenity 3.44.5

### DIFF
--- a/wireshark-wrapper.sh
+++ b/wireshark-wrapper.sh
@@ -13,7 +13,7 @@ if [[ "${SKIP_WARNING:-0}" != "1" ]]; then
       --height=100 \
       --ok-label="Run Wireshark" \
       --cancel-label="Exit" \
-      --text="⚠️  This Wireshark package does not support capturing data.\n\nPress \"Exit\" to close, \"Run Wireshark\" to continue"; then
+      --text="This Wireshark package does not support capturing data.\n\nPress \"Exit\" to close, \"Run Wireshark\" to continue"; then
       mkdir -p "$STATE_DIR" && touch "$STATE_FILE"
     else
       echo "Exiting."


### PR DESCRIPTION
Removing Attention emoji makes the wrapper work with the zenity shipped with org.kde.Platform 6.9.

There seems to be a regression in Zenity because the command works with an earlier version:
  https://gitlab.gnome.org/GNOME/zenity/-/issues/109

Once zenity works, we should revert this change.

@bbhtt do you happen to know anything about a regression in zenity?