### PR TITLE
nghttp2: do not build as it's in the runtime

### DIFF
--- a/org.wireshark.Wireshark.yml
+++ b/org.wireshark.Wireshark.yml
@@ -64,6 +64,8 @@ modules:
 
 
   - name: nghttp2
+    # nghttp2 is in the runtime
+    disabled: true
     cleanup:
       - /include
       - /share


### PR DESCRIPTION
fixes https://github.com/flathub/org.wireshark.Wireshark/issues/262